### PR TITLE
Add terms from Treasurer's primer

### DIFF
--- a/Handbook/Glossary.md
+++ b/Handbook/Glossary.md
@@ -4,14 +4,6 @@ The property assessment world is filled with lots of technical jargon that can m
 
 ## General
 
-#### Accrual Basis
-
-A way of measuring pension and other benefit funding levels that counts employee contributions when they are due, and benefit payments and refunds when they are made. Unlike [actuarial basis](#actuarial-basis), accrual basis does not weigh future benefit payments against investments and expected returns.
-
-#### Actuarial Basis
-
-A complex determination of whether investments held by a pension or other benefit plans are adequate to cover future expenses. The determination weighs expected future benefit payments against the level of investments and how much they are expected to earn over time, resulting in a determination of unfunded liability.
-
 #### Arm's Length Sale
 
 1. A sale between a willing buyer and a willing seller that are unrelated and are not acting under duress, abnormal pressure or undue influences.
@@ -248,7 +240,7 @@ A factor determined by the [Illinois Department of Revenue](#illinois-department
 
 #### Equalized Assessed Valuation (EAV)
 
-The [assessed value](#assessed-value-av) multiplied by the [equalization factor](#equalization-factor). The EAV is the value multiplied by a tax rate to calculate a property's tax bill.
+The [assessed value](#assessed-value-av) multiplied by the [equalization factor](#equalization-factor).
 
 #### First Installment
 
@@ -256,7 +248,7 @@ The first of two property tax bills sent out each year. This bill is 55% of the 
 
 #### Home Rule Government
 
-A municipal government granted additional authority, including added taxation powers, by the state of Illinois. Municipalities that have more than 25,000 residents are automatically granted home rule powers,
+A municipal government granted additional authority, including added taxation powers, by the state of Illinois. Municipalities that have more than 25,000 residents are automatically granted home rule powers.
 
 #### iasWorld
 

--- a/Handbook/Glossary.md
+++ b/Handbook/Glossary.md
@@ -4,6 +4,14 @@ The property assessment world is filled with lots of technical jargon that can m
 
 ## General
 
+#### Accrual Basis
+
+A way of measuring pension and other benefit funding levels that counts employee contributions when they are due, and benefit payments and refunds when they are made. Unlike [actuarial basis](#actuarial-basis), accrual basis does not weigh future benefit payments against investments and expected returns.
+
+#### Actuarial Basis
+
+A complex determination of whether investments held by a pension or other benefit plans are adequate to cover future expenses. The determination weighs expected future benefit payments against the level of investments and how much they are expected to earn over time, resulting in a determination of unfunded liability.
+
 #### Arm's Length Sale
 
 1. A sale between a willing buyer and a willing seller that are unrelated and are not acting under duress, abnormal pressure or undue influences.
@@ -11,12 +19,20 @@ The property assessment world is filled with lots of technical jargon that can m
 
 #### Assessed Value (AV)
 
-The value set by the CCAO for the purpose of computing property taxes. In some jurisdictions, assessed value is equal to [Fair Cash Value](#fair-cash-value-fcv). In Cook County, assessed value is:
+The value set by the [Assessor](#assessor), based on market conditions, for the purpose of computing property taxes. In some jurisdictions, assessed value is equal to [fair cash value](#fair-cash-value-fcv). In Cook County, assessed value is:
 
-   - 10% of [Fair Cash Value](#fair-cash-value-fcv) for [residential properties](#residential-property) (all class 200 properties, including condominiums)
-   - 25% of [Fair Cash Value](#fair-cash-value-fcv) for commercial properties (all class 500 properties)
+   - 10% of [fair cash value](#fair-cash-value-fcv) for [residential properties](#residential-property) (all class 200 properties, including condominiums)
+   - 25% of [fair cash value](#fair-cash-value-fcv) for commercial properties (all class 500 properties)
 
-These percentage multipliers are known as Assessment Levels.
+These percentage multipliers are known as [assessment levels](#assessment-level).
+
+#### Assessor
+
+The county or township official who determines assessed values of all properties within a jurisdiction for property tax purposes. In Illinois, assessors work at either the township or county level.
+
+#### Assessment Level
+
+The percentage of [fair cash value](#fair-cash-value-fcv) at which assessments are set within a jurisdiction.
 
 #### Automated Valuation Model (AVM)
 
@@ -24,11 +40,31 @@ A mathematical model which produces estimates of property market value based on 
 
 #### Class
 
-Groupings of properties defined by use and physical characteristics. Different classes are subject to different [assessment levels](#assessed-value-av).
+The designation of a property by type, such as vacant, residential, multi-family, agricultural, commercial or industrial. The classification determines the [percentage of fair cash value](#assessment-level) at which a property is assessed for taxing purposes.
+
+#### Clerk
+
+The county official who assigns property index numbers and calculates property tax rates applied to the value of each property within the county
 
 #### Computer-Assisted Mass Appraisal (CAMA)
 
 See [AVM](#automated-valuation-model-avm).
+
+#### Effective Tax Rate
+
+The percentage of a property’s fair market value paid in property taxes each year.
+
+#### Exempt Property
+
+Property removed from the tax base; may be a partial (a homestead) or complete (church building used exclusively for religious use).
+
+#### Exemption
+
+A reduction in assessed value based on the type of property, income and other factors granted to a property owner.
+
+#### Extension
+
+The process, conducted by the county clerk, of determining tax rates for each owners of certain types of property.
 
 #### Fair Cash Value (FCV)
 
@@ -36,15 +72,27 @@ The amount for which a property can be sold in the due course of business and tr
 
 #### Fair Market Value (FMV)
 
-Identical to [Fair Cash Value](#fair-cash-value-fcv). These terms are used interchangeably at the CCAO.
+Identical to [fair cash value](#fair-cash-value-fcv). These terms are used interchangeably at the CCAO.
 
-#### Exemption
+#### Forfeited
 
-Removal  of  property  from  the  tax  base;  may  be  a  partial  (a  homestead) or complete (church building used exclusively for religious use)
+The status of a property when the taxes are delinquent and a tax buyer did not purchase the [lien](#lien) on the delinquent taxes at the annual tax sale. In those cases, the county holds the [lien](#lien) to the property.
 
 #### IAAO
 
 The [International Association of Assessing Officers](https://www.iaao.org/). The IAAO (pronounced I double-A O) is the professional organization for assessors. It offers training, standards, and resources related to the process of assessment. It hosts an annual conference that many members of the CCAO attend.
+
+#### Leasehold Tax
+
+When for-profit companies lease space in a tax-exempt building owned by a non-profit or government entity, the for-profit company is liable for property taxes on the portion of property it uses. This is called a leasehold tax.
+
+#### Levy
+
+The total amount of taxes sought by a local government unit in a given year.
+
+#### Lien
+
+An unpaid debt legally assigned to a property. The holder of the lien is entitled to recoup their debt upon sale of the property.
 
 #### Property Index Number (PIN)
 
@@ -64,7 +112,7 @@ A property valued solely on the market valuation standard that is used, or inten
 
 #### Assessment Ratio
 
-The ratio of the assessor's estimated [Assessed Value](#assessed-value-av) to the property's sale price in the same period $`t`$:
+The ratio of the assessor's estimated [assessed value](#assessed-value-av) to the property's sale price in the same period $`t`$:
 
 ```math
 \text{Assessment Ratio}_t = \frac{\text{Assessor's Estimated Assessed Value}_t}{\text{Sale Price}_{t}}
@@ -82,7 +130,7 @@ COD = \frac{\text{Average Absolute Deviation From Median Ratio}}{\text{Median Ra
 
 #### Prediction Ratio
 
-See [Sales Ratio](#sales-ratio).
+See [sales ratio](#sales-ratio).
 
 #### Price Related Bias (PRB)
 
@@ -108,7 +156,7 @@ Also known as 'Selective Appraisal,' sales chasing is the practice of changing a
 
 #### Sales Ratio
 
-The ratio of the assessor's estimated [Fair Cash Value](#fair-cash-value-fcv) to the property's sale price in period $`t`$:
+The ratio of the assessor's estimated [fair cash value](#fair-cash-value-fcv) to the property's sale price in period $`t`$:
 
 ```math
 \text{Sales Ratio}_t = \frac{\text{Assessor's Estimated Fair Cash Value}_{t}}{\text{Sale Price}_{t}}
@@ -118,7 +166,8 @@ The ratio of the assessor's estimated [Fair Cash Value](#fair-cash-value-fcv) to
 
 #### Sales Ratio Study
 
-A statistical analysis to evaluate the quality of assessments with respect to accuracy, uniformity, and vertical equity.
+A statistical analysis to evaluate the quality of assessments with respect to accuracy, uniformity, and vertical equity. Compares assessed values to actual property
+sales transactions to determine whether assessments hit their proper assessment level.
 
 <br>
 
@@ -140,18 +189,22 @@ CI = \text{Mean} \pm \sigma / \sqrt n
 
 ## CCAO/Cook County/Illinois Specific
 
-#### AS/400
+#### Annual Tax Sale
 
-The machine used by the CCAO to communicate with the Cook County [Mainframe](#mainframe). Analysts interface with the AS/400 via an IBM System i terminal screen. Up until 2021, the AS/400 was the primary way analysts interacted with individual property records. The AS/400 has been effectively replaced by [iasWorld](#iasworld).
+The annual auction held by county treasurers to sell [liens](#lien) on property tax-delinquent properties.
 
 #### Appeals Process
 
-The official review of an assessment placed on a property. Also known as [Assessment Review](#assessment-review). Review can be up to four stages. Each stage can yield an adjustment in [Assessed Value](#assessed-value-av).
+The official review of an assessment placed on a property. Also known as [assessment review](#assessment-review). Review can be up to four stages. Each stage can yield an adjustment in [assessed value](#assessed-value-av).
 
 1. Appeal an assessment at the Assessor’s Office
 2. Appeal at the [Board of Review (BOR)](#board-of-review-bor)
 3. Appeal to the [Property Tax Appeal Board (PTAB)](#property-tax-appeal-board-ptab)
 4. File an objection in Circuit Court (only if filed at BoR)
+
+#### AS/400
+
+The machine used by the CCAO to communicate with the Cook County [mainframe](#mainframe). Analysts interface with the AS/400 via an IBM System i terminal screen. Up until 2021, the AS/400 was the primary way analysts interacted with individual property records. The AS/400 has been effectively replaced by [iasWorld](#iasworld).
 
 #### Assessment Cycle
 
@@ -167,7 +220,7 @@ The Cook County assessment cycle occurs in four primary stages:
 
 #### Assessment Review
 
-See [Appeals Process](#appeals-process).
+See [appeals process](#appeals-process).
 
 #### Board of Review (BoR)
 
@@ -185,19 +238,35 @@ A way to apply changes to a property tax bill that has already been issued (the 
 
 A designation in the Illinois chapter of the [IAAO](#iaao) certifying that the recipient has taken specific coursework in assessment/appraisal.
 
+#### Cook County Land Bank Authority
+
+A quasi-governmental agency that works to restore tax-delinquent and otherwise distressed properties to productive use. Most of its property has historically been obtained at the Scavenger Sale.
+
 #### Equalization Factor
 
-A factor determined by the Illinois Department of Revenue (IDOR) each year to ensure an equal assessment among all 102 counties in the state. State statute requires that the aggregate value of assessments within each county must be equalized at $`33 \frac{1}{3}\%`$ of the estimated [Fair Market Value](#fair-market-value-fmv) of real property in the county. This factor is also known as the "multiplier."
+A factor determined by the [Illinois Department of Revenue](#illinois-department-of-revenue-idor) each year to ensure an equal assessment among all 102 counties in the state. State statute requires that the aggregate value of assessments within each county must be equalized at $`33 \frac{1}{3}\%`$ of the estimated [fair market value](#fair-market-value-fmv) of real property in the county. This factor is also known as the "multiplier."
 
 #### Equalized Assessed Valuation (EAV)
 
-The [Assessed Value](#assessed-value-av) multiplied by the [Equalization Factor](#equalization-factor). The EAV is the value multiplied by a tax rate to calculate a property's tax bill.
+The [assessed value](#assessed-value-av) multiplied by the [equalization factor](#equalization-factor). The EAV is the value multiplied by a tax rate to calculate a property's tax bill.
+
+#### First Installment
+
+The first of two property tax bills sent out each year. This bill is 55% of the previous year’s property tax on the property being billed.
+
+#### Home Rule Government
+
+A municipal government granted additional authority, including added taxation powers, by the state of Illinois. Municipalities that have more than 25,000 residents are automatically granted home rule powers,
 
 #### iasWorld
 
 [Web portal link](https://iptsweb.ccounty.com/app/home#/dashboard) - Must be on CCAO network
 
-Property assessment and tax administration software produced by [Tyler Technologies](https://www.tylertech.com/products/iasworld). As of 2021, CCAO analysts use this software as their primary method of accessing individual property records. This system replaces the [AS/400](#as400) and will eventually replace the [Mainframe](#mainframe).
+Property assessment and tax administration software produced by [Tyler Technologies](https://www.tylertech.com/products/iasworld). As of 2021, CCAO analysts use this software as their primary method of accessing individual property records. This system replaces the [AS/400](#as400) and will eventually replace the [mainframe](#mainframe).
+
+#### Illinois Department of Revenue (IDOR)
+
+The state agency with myriad financial duties, including conducting sales/ratio studies and setting the equalization factor.
 
 #### Mainframe
 
@@ -205,7 +274,7 @@ Cook County's system of record for property taxes and assessments. Shared betwee
 
 #### Partial Assessment
 
-An [Assessed Value](#assessed-value-av) that is less than a full assessed value, because:
+An [assessed value](#assessed-value-av) that is less than a full assessed value, because:
 
 1. Improvements were added but were not usable for the entire tax year, or
 2. The taxable status of the property changed during the tax year.
@@ -214,19 +283,27 @@ New construction, building demolition, or fire occurring during the taxable year
 
 #### Property Tax Appeal Board (PTAB)
 
-A [quasi-judicial, state-level body](http://www.ptab.illinois.gov/) that also processes property tax appeals. Appeals are only considered by PTAB after being considered by the [Cook County Board of Review](#board-of-review-bor). See [Appeals Process](#appeals-process) for more information.
+A [quasi-judicial, state-level body](http://www.ptab.illinois.gov/) that also processes property tax appeals. Appeals are only considered by PTAB after being considered by the [Cook County Board of Review](#board-of-review-bor). See [appeals process](#appeals-process) for more information.
 
 #### PTAXSIM
 
 Short for Property Tax Simulator, [PTAXSIM](https://github.com/ccao-data/ptaxsim) is an application developed by the CCAO Data Department designed to replicate the property tax bill calculations performed by the Clerk/Treasurer. The goal of the application is to allow users to model different scenarios in order to more accurately predict how certain changes will affect the tax bill of a property.
 
+#### Illinois Property Tax Extension Limitation Law (PTELL)
+
+An Illinois statute that limits annual property tax increases by non-home rule governments to 5% or the increase in the consumer price index, whichever is less.
+
 #### RPIE
 
 The Real Property Income and Expense form. See the [RPIE pages](/RPIE/RPIE-Overview.md) on the wiki for more information.
 
+#### Second Installment
+
+The second of two property tax bills sent out each year. This bill is based on the current [levies](#levy) and [assessed values](#assessed-value-av). It amounts to the total tax bill for the year, minus the 55% of the prior year’s tax owed.
+
 #### Tax Base
 
-The total [Assessed Value](#assessed-value-av) of all properties. Sometimes broken out by area i.e the tax base of Rogers Park, which refers to the sum of all property [AVs](#assessed-value-av) in that town.
+The total [assessed value](#assessed-value-av) of all properties. Sometimes broken out by area i.e the tax base of Rogers Park, which refers to the sum of all property [AVs](#assessed-value-av) in that town.
 
 #### Tax Incentives
 
@@ -234,7 +311,7 @@ Incentives include [exemptions](#exemption), deferrals, abatements or tax credit
 
 #### Tax Increment Financing (TIF)
 
-A TIF is a special property tax district for a specific geographic area. TIFs are designed to encourage local development, fund specific projects, and help blighted areas. They work by effectively freezing the [Tax Base](#tax-base) of the TIF area, then funneling any additional tax revenues to a dedicated fund. TIFs expire after 23 years.
+A TIF is a special property tax district for a specific geographic area. TIFs are designed to encourage local development, fund specific projects, and help blighted areas. They work by effectively freezing the [tax base](#tax-base) of the TIF area, then funneling any additional tax revenues to a dedicated fund. TIFs expire after 23 years.
 
 See [City of Chicago resources on TIFs](https://www.chicago.gov/city/en/depts/dcd/provdrs/tif.html).
 
@@ -248,7 +325,11 @@ The tax levy divided by the total of all equalized assessed values. This figure 
 
 #### Taxing Body
 
-Units of governments that collect taxes to fund government services (the City of Chicago, Chicago Board of Education, Chicago Park District, County of Cook, and local school districts).
+Units of governments that collect taxes to fund government services (the City of Chicago, Chicago Board of Education, Chicago Park District, County of Cook, and local school districts). Also called a taxing agency.
+
+#### Taxing District
+
+The area within which a unit of local government levies taxes, a term also applied the to the local government levying those taxes.
 
 #### Taxpayer Information Services (TPI)
 
@@ -271,3 +352,4 @@ A department within the CCAO responsible for:
 
 * [IAAO Glossary](https://www.iaao.org/media/Pubs/IAAO_Glossary.pdf)
 * [CCAO Glossary](https://www.cookcountyassessor.com/glossary)
+* [Treasurer's Property Tax Primer](https://cookcountytreasurer.com/pdfs/understandingyourtaxbill/propertytaxprimer.pdf)


### PR DESCRIPTION
This PR adds terms to our Department glossary from the Treasurer's new property tax primer, found here: https://cookcountytreasurer.com/pdfs/understandingyourtaxbill/propertytaxprimer.pdf

It also cleans up some of the existing terms.