### PR TITLE
Fix source data typo in Open-Data.md

### DIFF
--- a/SOPs/Open-Data.md
+++ b/SOPs/Open-Data.md
@@ -122,7 +122,7 @@ The Data Department creates and maintains the following open data sets.
 
 **Use cases:** Can be used for geocoding or joining address-level data to other datasets.
 
-**Code:** [default-vw_pin_appeal.sql](https://github.com/ccao-data/data-architecture/blob/master/aws-athena/views/default-vw_pin_address.sql)
+**Code:** [default-vw_pin_address.sql](https://github.com/ccao-data/data-architecture/blob/master/aws-athena/views/default-vw_pin_address.sql)
 
 ### [Parcel Proximity](https://datacatalog.cookcountyil.gov/dataset/Assessor-Parcel-Proximity/ydue-e5u3)
 


### PR DESCRIPTION
This PR fixes a tiny typo in our open data documentation to ensure that the link to `vw_pin_address`, which documents the source view for the Parcel Addresses open data asset, displays the correct link text. Currently, the text displays `vw_pin_appeal` but the link points to `vw_pin_address`, and the latter is the correct source.