### PR TITLE
Update renv cache location

### DIFF
--- a/How-To/Administer-Users-on-CCAO-Services.md
+++ b/How-To/Administer-Users-on-CCAO-Services.md
@@ -37,7 +37,11 @@ To add new users to the Data server (and these applications), complete the follo
     ```
 3. Follow the prompts for user creation. Ask the user to create a password (if they are present) or generate a random one and share it with them securely.
 4. Test the new account. Visit the [RStudio](https://datascience.cookcountyassessor.com/rstudio/) login page and test the new account credentials. The account should work immediately.
-5. (Optional) [Use systemd and cgroups](https://unix.stackexchange.com/a/732460) to limit the resources available to a user (to prevent them from using 100% of the server's memory or CPU). To do so:
+5. Add the new user to the `data` Linux group to give them access to the [renv global cache](./Use-the-renv-global-cache.md).
+    ```bash
+    sudo usermod -aG data $THEIR_USER
+    ```
+6. (Optional) [Use systemd and cgroups](https://unix.stackexchange.com/a/732460) to limit the resources available to a user (to prevent them from using 100% of the server's memory or CPU). To do so:
     1. Create a slice configuration file for each user:
        ```
        sudo mkdir /etc/systemd/system/user-<uid>.slice.d
@@ -70,6 +74,7 @@ To delete users on the Data server, complete the following steps:
     ```bash
     sudo rmdir /home/$THEIR_USER
     ```
+
 ## AWS
 
 The Data Department stores most of its active data on AWS. Reading this data requires an authenticated AWS user account. Most users, such as interns and analysts, only require read access. To add a read-only user, complete the following steps:

--- a/How-To/Use-the-renv-global-cache.md
+++ b/How-To/Use-the-renv-global-cache.md
@@ -2,10 +2,10 @@
 
 [renv](https://rstudio.github.io/renv/articles/renv.html) is a common dependency management package for R. It can utilize a global cache to share packages between users and speed up installation. The Data Department uses this functionality on its internal server.
 
-When working in RStudio on the Data Department's server, new users will have a `.Renviron` file placed into their home directory by default. This file contains a pointer telling `renv` to use the global cache (located in the `/mnt/` directory). This prevents the same packages from being installed multiple times on the server and should save users time installing from source on Linux.
+When working in RStudio on the Data Department's server, new users will have a `.Renviron` file placed into their home directory by default. This file contains a pointer telling `renv` to use the global cache (located in the `/shared/` directory). This prevents the same packages from being installed multiple times on the server and should save users time installing from source on Linux.
 
 * For new users, there should no additional work needed for `renv` to function as desired
 * For previously added users:
   * Delete the directory `$USERNAME/.cache/R/renv`
-  * Add `RENV_PATHS_ROOT=/mnt/shared/renv` to `[user]/.Renviron`
+  * Add `RENV_PATHS_CACHE=/shared/renv/cache` to `/home/$USERNAME/.Renviron`
 


### PR DESCRIPTION
This PR updates the renv [cache location](https://rstudio.github.io/renv/reference/paths.html) on our shared server, moving it out of `/mnt/` and to a dedicated `/shared/` directory. Users will need to update their `.Renviron` files to point to the new location.