### PR TITLE
Add docs for setting up a local dev environment

### DIFF
--- a/Handbook/Dev-Environment-Setup.md
+++ b/Handbook/Dev-Environment-Setup.md
@@ -1,7 +1,15 @@
 # Dev environment setup
 
-These are the tools we expect every Data Team member to have set up on their
-laptop, i.e. their dev environment.
+This doc provides installation instructions for all of the tools you will need
+if you want to write code on your CCAO-issued laptop. We call this set of tools
+your "dev environment", and we sometimes refer to your laptop as your "local"
+environment.
+
+Your local dev environment is separate from [the Data Team
+server](/How-To/Use-the-Data-team-server.md), though we also often use the
+server to write code. None of the steps below are necessary in order to set up
+your dev environment on the server, since we have already prepared the server
+for programming tasks.
 
 ## Tools that IT needs to install
 

--- a/Handbook/Dev-Environment-Setup.md
+++ b/Handbook/Dev-Environment-Setup.md
@@ -9,15 +9,19 @@ Make sure IT has installed the latest version of the following tools on your
 laptop:
 
 - Whichever major web browser you prefer
-- [Positron](https://positron.posit.co/)
 - [WSL](https://learn.microsoft.com/en-us/windows/wsl/install)
   - WSL may come pre-installed on your laptop, but it's possible that
     the pre-installed version is not the correct one. To check whether you
     have the correct version installed, see if you can search for `WSL` in the
-    Windows Search bar. If an app shows up in the search results and you can
+    Windows Search bar. If a WSL app shows up in the search results and you can
     open that app to load a terminal, then you have the correct version. If you
-    don't see the app, or if the app does not load a terminal, then you will
-    need to contact IT to install the latest version of WSL.
+    don't see the WSL app, or if the app does not load a terminal when you open
+    it, then you will need to contact IT to install the latest version of WSL.
+- [Positron](https://positron.posit.co/)
+  - We recommend you connect Positron to WSL so that you can take advantage of
+    all of the Linux packages that we will help you install below. To do this,
+    open [the Positron Remote menu](https://positron.posit.co/remote-ssh) and
+    select the dropdown option "Connect to WSL".
 
 ## Tools that you can install yourself
 

--- a/Handbook/Dev-Environment-Setup.md
+++ b/Handbook/Dev-Environment-Setup.md
@@ -1,0 +1,221 @@
+# Dev environment setup
+
+These are the tools we expect every Data Team member to have set up on their
+laptop, i.e. their dev environment.
+
+## Tools that IT needs to install
+
+Make sure IT has installed the latest version of the following tools on your
+laptop:
+
+- Whichever major web browser you prefer
+- [Positron](https://positron.posit.co/)
+- [WSL](https://learn.microsoft.com/en-us/windows/wsl/install)
+  - WSL may come pre-installed on your laptop, but it's possible that
+    the pre-installed version is not the correct one. To check whether you
+    have the correct version installed, see if you can search for `WSL` in the
+    Windows Search bar. If an app shows up in the search results and you can
+    open that app to load a terminal, then you have the correct version. If you
+    don't see the app, or if the app does not load a terminal, then you will
+    need to contact IT to install the latest version of WSL.
+
+## Tools that you can install yourself
+
+Some of the following tools require [`sudo`](https://en.wikipedia.org/wiki/Sudo)
+to install. If `sudo` is required, the tool command listed below will
+include it. Using `sudo` will prompt you to input your WSL user password, which
+should be the same as your Active Directory user password if you just received
+your laptop. If you are using an old laptop on which you have already changed
+your Active Directory password at least once, however, your WSL user password
+will be the same as the Active Directory password you had set whenever WSL was
+first installed on your machine. If you're having trouble remembering your
+password, reach out to a senior staff member on the Data Team.
+
+Many of these tools require WSL to install, so make sure IT has installed the
+correct version of WSL for you before you start installing these tools.
+
+### Mandatory tools
+
+These tools are common across Data Team projects, so all Data Team members
+should install them.
+
+These tools must be installed in a WSL shell. The easiest way to open a
+
+- [Python](https://www.python.org/) and [pip](https://pip.pypa.io/en/stable/):
+
+```bash
+sudo apt install python3-pip
+```
+
+- [uv](https://docs.astral.sh/uv/):
+
+```bash
+curl -LsSf https://astral.sh/uv/install.sh | sh
+```
+
+- [R](https://cran.r-project.org/bin/linux/ubuntu/fullREADME.html):
+
+```bash
+# 1. Download the CRAN signing key and output it to a file on your keyring
+wget -qO- https://cloud.r-project.org/bin/linux/ubuntu/marutter_pubkey.asc | sudo gpg --dearmor -o /usr/share/keyrings/cran-keyring.gpg
+
+# 2. Make a new apt source and configure it to use the signing key
+echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/cran-keyring.gpg] https://cloud.r-project.org/bin/linux/ubuntu $(grep -oP '(?<=UBUNTU_CODENAME=).*' /etc/os-release || lsb_release -cs)-cran40" | sudo tee /etc/apt/sources.list.d/cran.list
+
+# 3. Refresh the package registry and install R
+sudo apt update && sudo apt install r-base r-base-dev
+```
+
+- [Quarto](https://quarto.org/):
+
+```bash
+# 1. Download `.deb` file from the official Quarto site:
+#    https://quarto.org/docs/download/index.html
+#    The exact link will change depending on the latest Quarto version, so you
+#    will need to update the variable definition below to set it to the correct
+#    link
+wget -qO quarto.deb "https://<insert-deb-file-url-here>"
+
+# 2. Verify that the hash of the `.deb` file matches the hash listed on the
+#    Quarto site (linked above)
+sha256sum quarto.deb
+
+# 3. If the hashes match, install the package
+sudo dpkg -i quarto.deb
+
+# 4. Remove the file you downloaded, now that `dpkg` has installed it
+rm quarto.deb
+```
+
+- A number of system packages required for R development (copy and paste
+  this whole block):
+
+```bash
+sudo apt install \
+  # Required for R `curl` package
+  libcurl4-openssl-dev \
+  # Required for R `openssl` package
+  libssl-dev \
+  # Required for R `xml2` package
+  libxml2-dev \
+  # Required for R `git2r` package
+  libgit2-dev \
+  # Required for R `pdftools` package
+  libpoppler-cpp-dev \
+  # Required for R `protolite` package
+  libprotobuf-dev protobuf-compiler \
+  # Geospatial packages required for R `sf` package
+  gdal-bin libudunits2-dev libgdal-dev libgeos-dev libproj-dev libsqlite3-dev \
+  # Graphic devices required for tidyverse
+  libpng-dev libfontconfig1-dev libfreetype6-dev \
+```
+
+- Install the AWS CLI and set it up per [our
+  instructions](How-To/Setup-the-AWS-Command-Line-Interface-and-Multi-factor-Authentication.md):
+
+```bash
+uv tool install awscli
+uv tool install aws-mfa
+```
+
+- Install pre-commit and set it up per [our
+  instructions](How-To/Use-pre-commit-to-lint-and-format-your-code.md#installing-pre-commit):
+
+```bash
+uv tool install pre-commit
+```
+
+### Optional tools
+
+These tools are only used in specific Data Team projects, so Data Team members
+do not need to install them unless they are responsible for maintaining that
+project:
+
+- [Terraform](https://developer.hashicorp.com/terraform) (only used in
+  [`aws-infrastructure`](https://github.com/ccao-data/aws-infrastructure/)):
+
+```bash
+# 1. Download the package signing key and add it to your keyring
+wget -O - https://apt.releases.hashicorp.com/gpg | sudo gpg --dearmor -o /usr/share/keyrings/hashicorp-archive-keyring.gpg
+
+# 2. Make a new apt source and configure it to use the signing key
+echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(grep -oP '(?<=UBUNTU_CODENAME=).*' /etc/os-release || lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/hashicorp.list
+
+# 3. Refresh the package registry and install R
+sudo apt update && sudo apt install terraform
+```
+
+- [Git LFS](https://github.com/git-lfs/git-lfs/blob/main/INSTALLING.md) (only
+  used in [`ptaxsim`](https://github.com/ccao-data/ptaxsim/)):
+
+```bash
+(. /etc/lsb-release &&
+curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh |
+sudo env os=ubuntu dist="${DISTRIB_CODENAME}" bash)
+```
+
+- Java Development Kit, required for R `tabulapdf` package (only used in
+  [`ptaxsim`](https://github.com/ccao-data/ptaxsim/)):
+
+```bash
+sudo apt install default-jdk
+```
+
+- [`jq`](https://jqlang.org/) (only used in a handful of GitHub workflows for
+  projects like
+  [`data-architecture`](https://github.com/ccao-data/data-architecture/), so
+  you only need it if you need to debug something it's doing in those
+  workflows):
+
+```bash
+sudo apt install jq libjq-dev
+```
+
+- [Hugo](https://gohugo.io/) (only used in
+  [`homeval`](https://github.com/ccao-data/homeval/)):
+
+```bash
+sudo snap install hugo
+```
+
+### Configurations
+
+The following configs will help you work more productively:
+
+- Create an `~/.Renviron` file with the following contents to use our default
+  AWS settings:
+
+```env
+AWS_REGION=us-east-1
+AWS_ATHENA_S3_STAGING_DIR=s3://ccao-athena-results-us-east-1/
+```
+
+- Create a [GitHub personal access token
+  (PAT)](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens)
+  and add it to `~/.Renviron` to use when installing R packages from GitHub:
+  - **⚠️ GitHub PATs are sensitive and should be treated like passwords.** We
+    will give your token as few permissions as possible to reduce the attack
+    surface, but you should still aim to keep it private and never publish it
+    in source code.
+  - Start by [generating a new classic personal access
+    token](https://github.com/settings/tokens/new). Select **only** the
+    `repo.public_repo` scope, hit "Generate token", and copy the PAT that
+    GitHub displays to you.  /p
+  - Paste your PAT onto a new line in your `~/.Renviron` file:
+
+```env
+GITHUB_PAT="<paste-your-PAT-here>"
+```
+
+- Create an `~/.Rprofile` file with the following contents:
+
+```R
+local({
+    # Set the CRAN repo
+    r <- getOption("repos")
+    r["CRAN"] <- "https://cloud.r-project.org"
+    options(repos = r)
+    # Enforce the less verbose version of the renv lockfile syntax
+    options(renv.lockfile.version = 1)
+})
+```

--- a/Handbook/Dev-Environment-Setup.md
+++ b/Handbook/Dev-Environment-Setup.md
@@ -33,17 +33,23 @@ laptop:
 
 ## Tools that you can install yourself
 
-Some of the following tools require [`sudo`](https://en.wikipedia.org/wiki/Sudo)
-to install. If `sudo` is required, the tool command listed below will
-include it.
+The instructions below will help you install tools that _don't_ require
+intervention from IT.
+
+### A few notes before you begin
+
+Some of the following tools require using the command
+[`sudo`](https://en.wikipedia.org/wiki/Sudo) in order to authorize your OS
+to perform the installation. If `sudo` is required to install a tool, then the
+tool command listed below will include it.
 
 Using `sudo` will prompt you to input your WSL user password, which
 should be the same as your Active Directory user password if you just received
-your laptop. If you are using an old laptop on which you have already changed
-your Active Directory password at least once, however, your WSL user password
-will be the same as the Active Directory password you had set whenever WSL was
-first installed on your laptop. If you're having trouble remembering your
-password, reach out to a senior staff member on the Data Team.
+your laptop. If you are using an old laptop, and you've already changed your
+Active Directory password at least once on that laptop, then your WSL user
+password will be the same as the Active Directory password that was active
+whenever IT first installed WSL on your laptop. If you're having trouble
+remembering your password, reach out to a senior staff member on the Data Team.
 
 Many of these tools require WSL to install, so make sure IT has installed the
 correct version of WSL for you before you start installing these tools.
@@ -56,28 +62,39 @@ should install them.
 These tools must be installed in a WSL shell. We recommend you do this in one
 of two ways:
 
-- Open the `WSL` app on your laptop to launch a WSL shell
-  - If you are comfortable working in a terminal separate from your code
-    editor, you can also configure the built-in Terminal app to launch WSL
-    shells by default
-- By connecting Positron to WSL in the Remote menu and opening the terminal
-  pane
+- **If you prefer using the terminal pane in your code editor of choice**:
+  Connect your code editor to WSL and open a terminal pane. In Positron, you
+  can do this by opening [the Remote
+  menu](https://positron.posit.co/remote-ssh), selecting the WSL option, and
+  then opening the terminal pane (`View > Terminal`).
+- **If you prefer using a dedicated terminal app**: Open the `WSL` app on
+  your laptop to launch a WSL shell.
+  - If you prefer working in a terminal separate from your code editor, you can
+    also take this opportunity to configure the built-in Windows Terminal app to
+    launch WSL shells by default. See [the docs for configuring Windows
+    Terminal](https://learn.microsoft.com/en-us/windows/terminal/install).
+    Ignore any instructions related to installing Windows Terminal,
+    since it should already be pre-installed on your laptop. (Feel free to skip
+    this configuration step if you prefer to work in the terminal pane in your
+    code editor.)
 
-Once you have a WSL shell open, install the following tools:
+Once you have a WSL shell open, run the following commands to install mandatory
+tools:
 
-- [Python](https://www.python.org/) and [pip](https://pip.pypa.io/en/stable/):
+- Install [Python](https://www.python.org/) and
+  [pip](https://pip.pypa.io/en/stable/):
 
 ```bash
 sudo apt install python3-pip
 ```
 
-- [uv](https://docs.astral.sh/uv/):
+- Install [uv](https://docs.astral.sh/uv/) for Python package management:
 
 ```bash
 curl -LsSf https://astral.sh/uv/install.sh | sh
 ```
 
-- [R](https://cran.r-project.org/bin/linux/ubuntu/fullREADME.html):
+- Install [R](https://cran.r-project.org/bin/linux/ubuntu/fullREADME.html):
 
 ```bash
 # 1. Download the CRAN signing key and output it to a file on your keyring
@@ -90,10 +107,19 @@ echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/cran-
 sudo apt update && sudo apt install r-base r-base-dev
 ```
 
-- [Quarto](https://quarto.org/):
+- Install [Quarto](https://quarto.org/) for authoring documents that run R or
+  Python code
+  - Note that there are two preliminary steps here:
+    1. Find the link to the latest version of the `.deb` package file for
+       Ubuntu on [the Quarto Downloads
+       page](https://quarto.org/docs/download/index.html), then substitute that
+       URL into command #1 below
+    2. Copy the SHA-256 hash file hash for the `.deb` package that you
+       downloaded, which should be displayed in the table on the Downloads
+       page, and note it for comparison to the output of command #2 below
 
 ```bash
-# 1. Download `.deb` file from the official Quarto site:
+# 1. Download the `.deb` package file from the official Quarto site:
 #    https://quarto.org/docs/download/index.html
 #    The exact link will change depending on the latest Quarto version, so you
 #    will need to update the variable definition below to set it to the correct
@@ -104,15 +130,17 @@ wget -qO quarto.deb "https://<insert-deb-file-url-here>"
 #    Quarto site (linked above)
 sha256sum quarto.deb
 
-# 3. If the hashes match, install the package
+# 3. If the hashes match, install the package; if hashes don't match, contact
+#    a senior Data Team member for assistance, since the mismatch might indicate
+#    a malicious package
 sudo dpkg -i quarto.deb
 
 # 4. Remove the file you downloaded, now that `dpkg` has installed it
 rm quarto.deb
 ```
 
-- A number of system packages required for R development (copy and paste
-  this whole block):
+- Install a number of system packages that are necessary for R development
+  (you can copy and paste this whole block to preserve the line breaks):
 
 ```bash
 sudo apt install \
@@ -131,13 +159,15 @@ sudo apt install \
     # Geospatial packages required for R `sf` package
     gdal-bin libudunits2-dev libgdal-dev libgeos-dev libproj-dev libsqlite3-dev \
     # Graphic devices required for tidyverse
-    libpng-dev libfontconfig1-dev libfreetype6-dev \
+    libpng-dev libfontconfig1-dev libfreetype6-dev
 ```
 
 - Install the AWS CLI and set it up per [our
   instructions](How-To/Setup-the-AWS-Command-Line-Interface-and-Multi-factor-Authentication.md):
 
 ```bash
+# Install the tools using these commands, then refer to the docs link above for
+# the necessary configuration steps
 uv tool install awscli
 uv tool install aws-mfa
 ```
@@ -146,15 +176,63 @@ uv tool install aws-mfa
   instructions](How-To/Use-pre-commit-to-lint-and-format-your-code.md#installing-pre-commit):
 
 ```bash
+# Install the tools using these commands, then refer to the docs link above for
+# the necessary configuration steps
 uv tool install pre-commit
+```
+
+### Mandatory R configurations
+
+The following configs will help you work with our R projects.
+
+- Create an `~/.Renviron` file with the following contents to use the correct
+  AWS settings when [querying data from our AWS Athena data
+  warehouse](https://github.com/ccao-data/wiki/blob/master/How-To/Connect-to-AWS-Resources.md#r):
+
+```env
+AWS_REGION=us-east-1
+AWS_ATHENA_S3_STAGING_DIR=s3://ccao-athena-results-us-east-1/
+```
+
+- Create a [GitHub personal access token
+  (PAT)](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens)
+  and add it to `~/.Renviron` to use when installing R packages from GitHub
+  - **⚠️ GitHub PATs are sensitive and should be treated like passwords.** The
+    instructions below will give your token as few permissions as possible in
+    order to reduce the attack surface of the token, but you should still aim
+    to keep it private, and you should definitely avoid including it in code
+    that you push to GitHub.
+  - Start by [generating a classic personal access
+    token](https://github.com/settings/tokens/new). Select **only** the
+    `repo.public_repo` scope, hit "Generate token", and copy the PAT that
+    GitHub displays to you.
+  - Paste your PAT onto a new line in your `~/.Renviron` file:
+
+```env
+GITHUB_PAT="<paste-your-PAT-inside-these-quotes>"
+```
+
+- Create an `~/.Rprofile` file with the following `local()` call to instruct
+  renv to use the `cloud.r-project.org` CRAN mirror and the legacy lockfile
+  syntax:
+
+```R
+local({
+    # Set the CRAN repo
+    r <- getOption("repos")
+    r["CRAN"] <- "https://cloud.r-project.org"
+    options(repos = r)
+    # Enforce the less verbose (legacy) version of the renv lockfile syntax
+    options(renv.lockfile.version = 1)
+})
 ```
 
 ### Optional tools
 
 These tools are only used in specific Data Team projects, so you do not need
-to install them unless they are responsible for maintaining that project.
+to install them unless you are responsible for maintaining that project.
 
-- [Terraform](https://developer.hashicorp.com/terraform) (only used in
+- Install [Terraform](https://developer.hashicorp.com/terraform) (only used in
   [`aws-infrastructure`](https://github.com/ccao-data/aws-infrastructure/)):
 
 ```bash
@@ -164,28 +242,26 @@ wget -O - https://apt.releases.hashicorp.com/gpg | sudo gpg --dearmor -o /usr/sh
 # 2. Make a new apt source and configure it to use the signing key
 echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(grep -oP '(?<=UBUNTU_CODENAME=).*' /etc/os-release || lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/hashicorp.list
 
-# 3. Refresh the package registry and install R
+# 3. Refresh the package registry and install Terraform
 sudo apt update && sudo apt install terraform
 ```
 
-- [Git LFS](https://github.com/git-lfs/git-lfs/blob/main/INSTALLING.md) (only
-  used in [`ptaxsim`](https://github.com/ccao-data/ptaxsim/)):
+- Install [Git LFS](https://github.com/git-lfs/git-lfs/blob/main/INSTALLING.md)
+  (only used in [`ptaxsim`](https://github.com/ccao-data/ptaxsim/)):
 
 ```bash
-(. /etc/lsb-release &&
-curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh |
-sudo env os=ubuntu dist="${DISTRIB_CODENAME}" bash)
+curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | sudo env os=ubuntu dist="$(grep -oP '(?<=UBUNTU_CODENAME=).*' /etc/os-release || lsb_release -cs)" bash
 ```
 
-- Java Development Kit, required for R `tabulapdf` package (only used in
-  [`ptaxsim`](https://github.com/ccao-data/ptaxsim/)):
+- Install the Java Development Kit, required for R `tabulapdf` package (only
+  used in [`ptaxsim`](https://github.com/ccao-data/ptaxsim/)):
 
 ```bash
 sudo apt install default-jdk
 ```
 
-- [`jq`](https://jqlang.org/) (only used in a handful of GitHub workflows for
-  projects like
+- Install [`jq`](https://jqlang.org/) (only used in a handful of GitHub
+  workflows for projects like
   [`data-architecture`](https://github.com/ccao-data/data-architecture/), so
   you only need it if you need to debug a `jq` command in one of those
   workflows):
@@ -194,51 +270,9 @@ sudo apt install default-jdk
 sudo apt install jq libjq-dev
 ```
 
-- [Hugo](https://gohugo.io/) (only used in
+- Install [Hugo](https://gohugo.io/) (only used in
   [`homeval`](https://github.com/ccao-data/homeval/)):
 
 ```bash
 sudo snap install hugo
-```
-
-### Configurations
-
-The following configs will help you work more productively:
-
-- Create an `~/.Renviron` file with the following contents to use our default
-  AWS settings:
-
-```env
-AWS_REGION=us-east-1
-AWS_ATHENA_S3_STAGING_DIR=s3://ccao-athena-results-us-east-1/
-```
-
-- Create a [GitHub personal access token
-  (PAT)](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens)
-  and add it to `~/.Renviron` to use when installing R packages from GitHub:
-  - **⚠️ GitHub PATs are sensitive and should be treated like passwords.** We
-    will give your token as few permissions as possible to reduce the attack
-    surface, but you should still aim to keep it private and never publish it
-    in source code.
-  - Start by [generating a new classic personal access
-    token](https://github.com/settings/tokens/new). Select **only** the
-    `repo.public_repo` scope, hit "Generate token", and copy the PAT that
-    GitHub displays to you.  /p
-  - Paste your PAT onto a new line in your `~/.Renviron` file:
-
-```env
-GITHUB_PAT="<paste-your-PAT-here>"
-```
-
-- Create an `~/.Rprofile` file with the following contents:
-
-```R
-local({
-    # Set the CRAN repo
-    r <- getOption("repos")
-    r["CRAN"] <- "https://cloud.r-project.org"
-    options(repos = r)
-    # Enforce the less verbose version of the renv lockfile syntax
-    options(renv.lockfile.version = 1)
-})
 ```

--- a/Handbook/Dev-Environment-Setup.md
+++ b/Handbook/Dev-Environment-Setup.md
@@ -35,12 +35,14 @@ laptop:
 
 Some of the following tools require [`sudo`](https://en.wikipedia.org/wiki/Sudo)
 to install. If `sudo` is required, the tool command listed below will
-include it. Using `sudo` will prompt you to input your WSL user password, which
+include it.
+
+Using `sudo` will prompt you to input your WSL user password, which
 should be the same as your Active Directory user password if you just received
 your laptop. If you are using an old laptop on which you have already changed
 your Active Directory password at least once, however, your WSL user password
 will be the same as the Active Directory password you had set whenever WSL was
-first installed on your machine. If you're having trouble remembering your
+first installed on your laptop. If you're having trouble remembering your
 password, reach out to a senior staff member on the Data Team.
 
 Many of these tools require WSL to install, so make sure IT has installed the
@@ -51,7 +53,17 @@ correct version of WSL for you before you start installing these tools.
 These tools are common across Data Team projects, so all Data Team members
 should install them.
 
-These tools must be installed in a WSL shell. The easiest way to open a
+These tools must be installed in a WSL shell. We recommend you do this in one
+of two ways:
+
+- Open the `WSL` app on your laptop to launch a WSL shell
+  - If you are comfortable working in a terminal separate from your code
+    editor, you can also configure the built-in Terminal app to launch WSL
+    shells by default
+- By connecting Positron to WSL in the Remote menu and opening the terminal
+  pane
+
+Once you have a WSL shell open, install the following tools:
 
 - [Python](https://www.python.org/) and [pip](https://pip.pypa.io/en/stable/):
 
@@ -104,22 +116,22 @@ rm quarto.deb
 
 ```bash
 sudo apt install \
-  # Required for R `curl` package
-  libcurl4-openssl-dev \
-  # Required for R `openssl` package
-  libssl-dev \
-  # Required for R `xml2` package
-  libxml2-dev \
-  # Required for R `git2r` package
-  libgit2-dev \
-  # Required for R `pdftools` package
-  libpoppler-cpp-dev \
-  # Required for R `protolite` package
-  libprotobuf-dev protobuf-compiler \
-  # Geospatial packages required for R `sf` package
-  gdal-bin libudunits2-dev libgdal-dev libgeos-dev libproj-dev libsqlite3-dev \
-  # Graphic devices required for tidyverse
-  libpng-dev libfontconfig1-dev libfreetype6-dev \
+    # Required for R `curl` package
+    libcurl4-openssl-dev \
+    # Required for R `openssl` package
+    libssl-dev \
+    # Required for R `xml2` package
+    libxml2-dev \
+    # Required for R `git2r` package
+    libgit2-dev \
+    # Required for R `pdftools` package
+    libpoppler-cpp-dev \
+    # Required for R `protolite` package
+    libprotobuf-dev protobuf-compiler \
+    # Geospatial packages required for R `sf` package
+    gdal-bin libudunits2-dev libgdal-dev libgeos-dev libproj-dev libsqlite3-dev \
+    # Graphic devices required for tidyverse
+    libpng-dev libfontconfig1-dev libfreetype6-dev \
 ```
 
 - Install the AWS CLI and set it up per [our
@@ -139,9 +151,8 @@ uv tool install pre-commit
 
 ### Optional tools
 
-These tools are only used in specific Data Team projects, so Data Team members
-do not need to install them unless they are responsible for maintaining that
-project:
+These tools are only used in specific Data Team projects, so you do not need
+to install them unless they are responsible for maintaining that project.
 
 - [Terraform](https://developer.hashicorp.com/terraform) (only used in
   [`aws-infrastructure`](https://github.com/ccao-data/aws-infrastructure/)):
@@ -176,7 +187,7 @@ sudo apt install default-jdk
 - [`jq`](https://jqlang.org/) (only used in a handful of GitHub workflows for
   projects like
   [`data-architecture`](https://github.com/ccao-data/data-architecture/), so
-  you only need it if you need to debug something it's doing in those
+  you only need it if you need to debug a `jq` command in one of those
   workflows):
 
 ```bash

--- a/Handbook/Local-Dev-Environment-Setup.md
+++ b/Handbook/Local-Dev-Environment-Setup.md
@@ -1,9 +1,9 @@
-# Dev environment setup
+# Local dev environment setup
 
 This doc provides installation instructions for all of the tools you will need
 if you want to write code on your CCAO-issued laptop. We call this set of tools
-your "dev environment", and we sometimes refer to your laptop as your "local"
-environment.
+your "dev environment", and we refer to it as a "local" environment since it
+exists on your laptop instead of a remote server.
 
 Your local dev environment is separate from [the Data Team
 server](/How-To/Use-the-Data-team-server.md), though we also often use the

--- a/Handbook/Local-Dev-Environment-Setup.md
+++ b/Handbook/Local-Dev-Environment-Setup.md
@@ -17,7 +17,8 @@ Make sure IT has installed the latest version of the following tools on your
 laptop:
 
 - Whichever major web browser you prefer
-- [WSL](https://learn.microsoft.com/en-us/windows/wsl/install)
+- [WSL](https://learn.microsoft.com/en-us/windows/wsl/install) with Ubuntu
+  24.04 or 26.04
   - WSL may come pre-installed on your laptop, but it's possible that
     the pre-installed version is not the correct one. To check whether you
     have the correct version installed, see if you can search for `WSL` in the
@@ -85,10 +86,12 @@ tools:
   [pip](https://pip.pypa.io/en/stable/):
 
 ```bash
-sudo apt install python3-pip
+sudo apt update && sudo apt install python3-pip
 ```
 
-- Install [uv](https://docs.astral.sh/uv/) for Python package management:
+- Install [uv](https://docs.astral.sh/uv/) for Python package management. After
+  this command finishes executing, you will need to restart your shell (i.e.
+  open a new terminal pane) in order to be able to run `uv` commands:
 
 ```bash
 curl -LsSf https://astral.sh/uv/install.sh | sh
@@ -143,26 +146,31 @@ rm quarto.deb
   (you can copy and paste this whole block to preserve the line breaks):
 
 ```bash
-sudo apt install \
-    # Required for R `curl` package
+# The core dependencies that rely on these packages are:
+#
+#   - Required for R `curl` package: libcurl4-openssl-dev
+#   - Required for R `openssl` package: libssl-dev
+#   - Required for R `xml2` package: libxml2-dev
+#   - Required for R `git2r` package: libgit2-dev
+#   - Required for R `pdftools` package: libpoppler-cpp-dev
+#   - Required for R `protolite` package: libprotobuf-dev, protobuf-compiler
+#   - Required for R `fs` package: libuv1-dev
+#   - Required for R `textshaping` package: libharfbuzz-dev, libfribidi-dev
+#   - Geospatial packages required for R `sf` package:
+#     gdal-bin, libudunits2-dev, libgdal-dev, libgeos-dev, libproj-dev,
+#     libsqlite3-dev
+#   - Graphic devices required for tidyverse: libpng-dev, libfontconfig1-dev,
+#     libfreetype6-dev
+sudo apt update && sudo apt install \
     libcurl4-openssl-dev \
-    # Required for R `openssl` package
     libssl-dev \
-    # Required for R `xml2` package
     libxml2-dev \
-    # Required for R `git2r` package
     libgit2-dev \
-    # Required for R `pdftools` package
     libpoppler-cpp-dev \
-    # Required for R `protolite` package
     libprotobuf-dev protobuf-compiler \
-    # Required for R `fs` package
     libuv1-dev \
-    # Required for R `textshaping` package
     libharfbuzz-dev libfribidi-dev \
-    # Geospatial packages required for R `sf` package
     gdal-bin libudunits2-dev libgdal-dev libgeos-dev libproj-dev libsqlite3-dev \
-    # Graphic devices required for tidyverse
     libpng-dev libfontconfig1-dev libfreetype6-dev
 ```
 
@@ -280,3 +288,29 @@ sudo apt install jq libjq-dev
 ```bash
 sudo snap install hugo
 ```
+
+## Editing local files using Positron
+
+Once you've completed all of the above steps to setup your local dev
+environment, you're ready to start writing and editing code. Though we don't
+require Data Team members to use a specific editor, most of us use Positron
+for running and editing local R and Python code.
+
+When editing local files using Positron, **always make sure you're connected to
+the WSL remote**. You can do this using [the Positron Remote
+menu](https://positron.posit.co/remote-ssh). While connected to the WSL remote,
+Positron will edit files in the WSL filesystem rather than on your Windows
+filesystem.
+
+This distinction is important to keep in mind: **WSL uses a totally separate
+filesystem from Windows**. WSL is a Linux operating system running in a
+lightweight virtual machine on your Windows host, so files that you create
+and edit in WSL are not visible in Windows apps like File Explorer. To access
+these files from your Windows operating system, you need to open them from
+within WSL, which is what the Positron WSL remote does. (You can also go the
+other direction by mounting Windows drives into WSL; in fact, your `C:\` drive
+should already be mounted into WSL by default at `/mnt/c`.)
+
+Once you're connected to the WSL remote in Positron, Positron will open files
+and folders in WSL any time you run the command `File > New File` or
+`File > Open File[/Folder]`.

--- a/Handbook/Local-Dev-Environment-Setup.md
+++ b/Handbook/Local-Dev-Environment-Setup.md
@@ -156,6 +156,10 @@ sudo apt install \
     libpoppler-cpp-dev \
     # Required for R `protolite` package
     libprotobuf-dev protobuf-compiler \
+    # Required for R `fs` package
+    libuv1-dev \
+    # Required for R `textshaping` package
+    libharfbuzz-dev libfribidi-dev \
     # Geospatial packages required for R `sf` package
     gdal-bin libudunits2-dev libgdal-dev libgeos-dev libproj-dev libsqlite3-dev \
     # Graphic devices required for tidyverse

--- a/Handbook/Local-Dev-Environment-Setup.md
+++ b/Handbook/Local-Dev-Environment-Setup.md
@@ -114,20 +114,23 @@ sudo apt update && sudo apt install r-base r-base-dev
   Python code
   - Note that there are two preliminary steps here:
     1. Find the link to the latest version of the `.deb` package file for
-       Ubuntu on [the Quarto Downloads
-       page](https://quarto.org/docs/download/index.html), then substitute that
-       URL into command #1 below
-    2. Copy the SHA-256 hash file hash for the `.deb` package that you
+       Ubuntu 18+/Debian 10+ on [the Quarto Downloads
+       page](https://quarto.org/docs/download/index.html), copy that link, and
+       substitute the URL into command #1 below
+    2. Copy the SHA-256 file hash for the `.deb` package that you
        downloaded, which should be displayed in the table on the Downloads
        page, and note it for comparison to the output of command #2 below
 
 ```bash
-# 1. Download the `.deb` package file from the official Quarto site:
+# 1. This step downloads the `.deb` package file from the official Quarto
+#    distribution into WSL. The exact link to the correct `.deb` package file
+#    changes depending on the latest Quarto version, so we can't hardcode the
+#    download link in the `wget` command below. In order for `wget` to retrieve
+#    the correct file, you must visit the following URL, copy the link address
+#    for the `.deb` file labeled with the platform "Ubuntu 18+/Debian 10+", and
+#    then paste it into the `wget` command below before running that command:
 #    https://quarto.org/docs/download/index.html
-#    The exact link will change depending on the latest Quarto version, so you
-#    will need to update the variable definition below to set it to the correct
-#    link
-wget -qO quarto.deb "https://<insert-deb-file-url-here>"
+wget -qO quarto.deb "https://<deb-file-url-here>"
 
 # 2. Verify that the hash of the `.deb` file matches the hash listed on the
 #    Quarto site (linked above)

--- a/How-To/Setup-the-AWS-Command-Line-Interface-and-Multi-factor-Authentication.md
+++ b/How-To/Setup-the-AWS-Command-Line-Interface-and-Multi-factor-Authentication.md
@@ -2,14 +2,16 @@ The AWS CLI allows users to interact directly with AWS services such S3, Athena,
 
 Our account setup requires multi-factor authentication (MFA) to use most services. The easiest way to setup MFA is using the third-party `aws-mfa` tool.
 
+The following instructions assume you are running commands in a Linux terminal, either on the server or in a WSL session on your laptop.
+
 ---
   
-1. Install the AWS command line interface using [the provided executable](https://aws.amazon.com/cli/) or `pip install awscli`, which allows users to store credentials, query Athena, move S3 objects, etc. The CLI on Windows can be accessed via PowerShell. On Linux or macOS it can be accessed via a standard terminal. If your intention is to connect to AWS via the Data team server, ensure that you are connected and logged in to the server first. 
+1. Install the AWS command line interface, which allows users to store credentials, query Athena, move S3 objects, etc: `uv tool install awscli`
 2. Log into the [AWS Console](https://ccao-data.signin.aws.amazon.com/console) and under your account select "My Security Credentials". Enable MFA, then create an access key. You'll need both the `Access Key ID`, the `Secret Access Key`, and the name of the `Assigned MFA Device`. Do not include `(Virtual)` when copying the name of the MFA device.
 3. In the command line run:
    - `aws configure` and enter your `Access Key ID`, `Secret Access Key`, region (`us-east-1`), and `json` for output.
-   - `pip install aws-mfa`
-4. Open your credentials file located at `~/.aws/credentials` on Linux or macOS, or at `C:\Users\$USERNAME\.aws\credentials` on Windows and rename `[default]` to `[default-long-term]`.
+   - `uv tool install aws-mfa`
+4. Open your credentials file located at `~/.aws/credentials` and rename `[default]` to `[default-long-term]`.
 5. Underneath `aws_secret_access_key` type `aws_mfa_device = $MFA_DEVICE` where `$MFA_DEVICE` is the previously copied `Assigned MFA Device` from the AWS Console. Save the file.
 6. In the command line, run `aws-mfa` and enter the current MFA token provided by your `Assigned MFA Device`.
 7. Note, this command will only store MFA credentials for 12 hours (unless the duration is explicitly changed when running `aws-mfa`).

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 * [Resources](Handbook/Resources.md)
 * [Glossary](Handbook/Glossary.md)
 * [Accounts](Handbook/Accounts.md)
-* [Dev Environment Setup](Handbook/Dev-Environment-Setup.md)
+* [Local Dev Environment Setup](Handbook/Local-Dev-Environment-Setup.md)
 * [Not Public](Handbook/Not-Public.md)
 
 ### People and Onboarding

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 * [Resources](Handbook/Resources.md)
 * [Glossary](Handbook/Glossary.md)
 * [Accounts](Handbook/Accounts.md)
+* [Dev Environment Setup](Handbook/Dev-Environment-Setup.md)
 * [Not Public](Handbook/Not-Public.md)
 
 ### People and Onboarding


### PR DESCRIPTION
This PR adds a new doc `Handbook/Local-Dev-Environment-Setup.md` that documents the steps required to set up a development environment on a local machine (i.e. a laptop).

I'm hoping I can get a couple folks to review this for clarity, and then one person (perhaps Kyra or Damon) to test it out and see if all the commands work.

Connects https://github.com/ccao-data/people/issues/33.