### PR TITLE
Clarify docs for renewing server SSL certificate

### DIFF
--- a/How-To/Issue-a-certificate-for-the-data-team-server.md
+++ b/How-To/Issue-a-certificate-for-the-data-team-server.md
@@ -3,6 +3,12 @@ controller to provide HTTPS for its internal server. This certificate
 occassionally needs to be manually renewed by an administrative or IT staff
 member. This guide walks through how to create/renew the certificate.
 
+> [!WARNING]  
+> This process involves some confusing steps, and must take place after hours
+> so as not to disrupt users of the Data Team server. Try to perform this
+> renewal at least a week in advance of the certificate expiration so that
+> you can work with IT to resolve any issues that may arise.
+
 ## Create a certificate
 
 1. Open the Certificate Manager app by pressing `Windows + R`, then typing
@@ -13,28 +19,33 @@ select the **Certificates** directory.
 **All Tasks > Request New Certificate**.
 4. Click **Next**, keep `Active Directory Enrollment Policy` selected, then
 click **Next** again.
-5. Under `Active Directory Enrollment Policy`, select `CCAO EFS` or
-`CCAO WEB2`, click the **Details** down arrow to the right of the policy,
-then click **Properties**.
-5. On the **General** tab of the popup, make the friendly name the name of the server
+5. Under `Active Directory Enrollment Policy`, select `CCAO WEB2`, click the
+**Details** down arrow to the right of the policy, then click **Properties**.
+    - If you have never renewed this certificate before, you may not see the
+      `CCAO WEB2` certificate template in the "Request Certificates" menu,
+      or you may get a generic error saying you don't have permission to
+      request certificates at all. In either of these cases, reach out to IT
+      to ask them to give you permissions to request certificates using the
+      `CCAO WEB2` certificate template.
+7. On the **General** tab of the popup, make the friendly name the name of the server
 `datascience.cookcountyassessor.com`.
-6. Switch to the **Subject** tab, under the `Subject name` field, select
+8. Switch to the **Subject** tab, under the `Subject name` field, select
 `Common name` and add a value of `datascience.cookcountyassessor.com`, then
 click the **Add >** button.
-7. Repeat the process of adding `Subject name` values for the following:
+9. Repeat the process of adding `Subject name` values for the following:
     - `Country`: US
     - `State`: Illinois
     - `Locality`: Chicago
     - `Email`: Email of whoever is making the cert
     - `Organization`: Cook County Assessor's Office
     - `Organization unit`: Data Department
-8. Under the `Alternative name` field, select `DNS` and add a value of
+10. Under the `Alternative name` field, select `DNS` and add a value of
 `datascience.cookcountyassessor.com`, then click the **Add >** button.
-9. Switch to the **Private Key** tab. Under **Key options**, check the box
+11. Switch to the **Private Key** tab. Under **Key options**, check the box
 for `Make private key exportable`.
-10. Hit **Apply** in the bottom right of the popup. Then click **Next** to
+12. Hit **Apply** in the bottom right of the popup. Then click **Enroll** to
 create the new certificate.
-11. Click **Finish** to return to the Certificate Manager. You should see
+13. Click **Finish** to return to the Certificate Manager. You should see
 your new certificate in the list.
 
 ## Export the certificate
@@ -44,10 +55,11 @@ Now that the certificate is created, we need to export it for NGINX. To do so:
 1. Right-click the newly created certificate, then click
 **All Tasks > Export**. Click **Next**.
 2. Select `Yes, export the private key` option, then click **Next**.
-3. Select `Export all extended properties` then click **Next**.
-4. Select the `Password` option, enter an arbitrary strong password you'll
+3. Select `Export all extended properties`. Leave all of the
+other options set to their defaults. Then, click **Next**.
+5. Select the `Password` option, enter an arbitrary strong password you'll
 remember, then click **Next**.
-5. Select an export location and filename (the extension should be `.pfx`),
+6. Select an export location using the filename `datascience.cookcountyassessor.com.pfx`,
 then click **Next**, then **Finish** to save the file.
 
 ## Disaggregate the certificate
@@ -81,17 +93,20 @@ You now have a signed certificate and private key file for use with NGINX.
 All that's left to do is to install them in the appropriate directory and set
 the correct permissions.
 
-1. Move the `.key` and `.crt` files you just created to
+1. Move the `.key`, `.pfx`, and `.crt` files you just created to
 `$NGINX_DIRECTORY/secrets`. Where `$NGINX_DIRECTORY` is wherever the CCAO's
 [nginx service](https://github.com/ccao-data/service-nginx) is running.
-2. Set the owner of the key and certificate files to root with the following
-command:
+2. Set the owner of the key and certificate files to root:
     ```
-    sudo chown -r root:root $NGINX_DIRECTORY/secrets/*
+    sudo chown root:root $NGINX_DIRECTORY/secrets/datascience.cookcountyassessor.com.pfx
+    sudo chown root:root $NGINX_DIRECTORY/secrets/datascience.cookcountyassessor.com.crt
+    sudo chown root:root $NGINX_DIRECTORY/secrets/datascience.cookcountyassessor.com.key
     ```
 3. Set the permissions of the key and cert files to read-only for user:
     ```
-    sudo chmod -r 600 $NGINX_DIRECTORY/secrets/*
+    sudo chmod 600 $NGINX_DIRECTORY/secrets/datascience.cookcountyassessor.com.pfx
+    sudo chmod 600 $NGINX_DIRECTORY/secrets/datascience.cookcountyassessor.com.crt
+    sudo chmod 600 $NGINX_DIRECTORY/secrets/datascience.cookcountyassessor.com.key
     ```
 4. Restart NGINX using `docker compose`. In `$NGINX_DIRECTORY`:
     ```

--- a/How-To/Issue-a-certificate-for-the-data-team-server.md
+++ b/How-To/Issue-a-certificate-for-the-data-team-server.md
@@ -57,9 +57,9 @@ Now that the certificate is created, we need to export it for NGINX. To do so:
 2. Select `Yes, export the private key` option, then click **Next**.
 3. Select `Export all extended properties`. Leave all of the
 other options set to their defaults. Then, click **Next**.
-5. Select the `Password` option, enter an arbitrary strong password you'll
+4. Select the `Password` option, enter an arbitrary strong password you'll
 remember, then click **Next**.
-6. Select an export location using the filename `datascience.cookcountyassessor.com.pfx`,
+5. Select an export location using the filename `datascience.cookcountyassessor.com.pfx`,
 then click **Next**, then **Finish** to save the file.
 
 ## Disaggregate the certificate
@@ -93,22 +93,31 @@ You now have a signed certificate and private key file for use with NGINX.
 All that's left to do is to install them in the appropriate directory and set
 the correct permissions.
 
-1. Move the `.key`, `.pfx`, and `.crt` files you just created to
-`$NGINX_DIRECTORY/secrets`. Where `$NGINX_DIRECTORY` is wherever the CCAO's
-[nginx service](https://github.com/ccao-data/service-nginx) is running.
-2. Set the owner of the key and certificate files to root:
+1. Back up the existing `.key`, `.pfx`, and `.crt` files that are in
+`$NGINX_DIRECTORY/secrets`, where `$NGINX_DIRECTORY` is wherever the CCAO's
+[NGINX service](https://github.com/ccao-data/service-nginx) is running.
+    ```
+    export CURRENT_DATE=$(date '+%Y-%m-%d')
+    sudo mkdir $NGINX_DIRECTORY/secrets/old-$CURRENT_DATE/
+    sudo cp $NGINX_DIRECTORY/secrets/datascience.cookcountyassessor.com.pfx $NGINX_DIRECTORY/secrets/old-$CURRENT_DATE/
+    sudo cp $NGINX_DIRECTORY/secrets/datascience.cookcountyassessor.com.crt $NGINX_DIRECTORY/secrets/old-$CURRENT_DATE/
+    sudo cp $NGINX_DIRECTORY/secrets/datascience.cookcountyassessor.com.key $NGINX_DIRECTORY/secrets/old-$CURRENT_DATE/
+    ```
+2. Move the `.key`, `.pfx`, and `.crt` files you just created to
+`$NGINX_DIRECTORY/secrets/`, overwriting the old cert files you just backed up.
+3. Set the owner of the key and certificate files to root:
     ```
     sudo chown root:root $NGINX_DIRECTORY/secrets/datascience.cookcountyassessor.com.pfx
     sudo chown root:root $NGINX_DIRECTORY/secrets/datascience.cookcountyassessor.com.crt
     sudo chown root:root $NGINX_DIRECTORY/secrets/datascience.cookcountyassessor.com.key
     ```
-3. Set the permissions of the key and cert files to read-only for user:
+4. Set the permissions of the key and cert files to read-only for user:
     ```
     sudo chmod 600 $NGINX_DIRECTORY/secrets/datascience.cookcountyassessor.com.pfx
     sudo chmod 600 $NGINX_DIRECTORY/secrets/datascience.cookcountyassessor.com.crt
     sudo chmod 600 $NGINX_DIRECTORY/secrets/datascience.cookcountyassessor.com.key
     ```
-4. Restart NGINX using `docker compose`. In `$NGINX_DIRECTORY`:
+5. Restart NGINX using `docker compose`. In `$NGINX_DIRECTORY`:
     ```
     docker compose down
     docker compose up -d

--- a/How-To/Issue-a-certificate-for-the-data-team-server.md
+++ b/How-To/Issue-a-certificate-for-the-data-team-server.md
@@ -27,25 +27,25 @@ click **Next** again.
       request certificates at all. In either of these cases, reach out to IT
       to ask them to give you permissions to request certificates using the
       `CCAO WEB2` certificate template.
-7. On the **General** tab of the popup, make the friendly name the name of the server
+6. On the **General** tab of the popup, make the friendly name the name of the server
 `datascience.cookcountyassessor.com`.
-8. Switch to the **Subject** tab, under the `Subject name` field, select
+7. Switch to the **Subject** tab, under the `Subject name` field, select
 `Common name` and add a value of `datascience.cookcountyassessor.com`, then
 click the **Add >** button.
-9. Repeat the process of adding `Subject name` values for the following:
+8. Repeat the process of adding `Subject name` values for the following:
     - `Country`: US
     - `State`: Illinois
     - `Locality`: Chicago
     - `Email`: Email of whoever is making the cert
     - `Organization`: Cook County Assessor's Office
     - `Organization unit`: Data Department
-10. Under the `Alternative name` field, select `DNS` and add a value of
+9. Under the `Alternative name` field, select `DNS` and add a value of
 `datascience.cookcountyassessor.com`, then click the **Add >** button.
-11. Switch to the **Private Key** tab. Under **Key options**, check the box
+10. Switch to the **Private Key** tab. Under **Key options**, check the box
 for `Make private key exportable`.
-12. Hit **Apply** in the bottom right of the popup. Then click **Enroll** to
+11. Hit **Apply** in the bottom right of the popup. Then click **Enroll** to
 create the new certificate.
-13. Click **Finish** to return to the Certificate Manager. You should see
+12. Click **Finish** to return to the Certificate Manager. You should see
 your new certificate in the list.
 
 ## Export the certificate


### PR DESCRIPTION
The server cert renewal didn't go very smoothly this year. Although I was able to create a cert by following the instructions, the certificate did not appear valid when we sent requests to the RStudio console from the browser. In particular, the domain name was wrong, and none of the other cert properties appeared to be populated. We ended up with two days of downtime, and we had to call in IT for help at the last minute.

The root cause turned out to be that I did not have permissions to request a certificate using the correct certificate template `CCAO WEB2`. The docs said that either the `CCAO WEB2` template or the `CCAO EFS` template should work fine, so I issued the certificate using `CCAO EFS`. However, `CCAO EFS` is not actually a workable template for this type of certificate, and it ended up issuing a certificate for my laptop hostname instead of the server domain. Once IT was able to give me permissions to request certificates using `CCAO WEB2`, the docs were correct and easy to follow.

This PR updates the docs to clarify that the certificate template _must_ be `CCAO WEB2`, and also tweaks a few small bits of language that I found to be confusing.