### PR TITLE
Update AWS CLI install instructions to use uv

### DIFF
--- a/How-To/Setup-the-AWS-Command-Line-Interface-and-Multi-factor-Authentication.md
+++ b/How-To/Setup-the-AWS-Command-Line-Interface-and-Multi-factor-Authentication.md
@@ -4,11 +4,11 @@ Our account setup requires multi-factor authentication (MFA) to use most service
 
 ---
   
-1. Install the AWS command line interface using [the provided executable](https://aws.amazon.com/cli/) or `pip install awscli`, which allows users to store credentials, query Athena, move S3 objects, etc. The CLI on Windows can be accessed via PowerShell. On Linux or macOS it can be accessed via a standard terminal. If your intention is to connect to AWS via the Data team server, ensure that you are connected and logged in to the server first. 
+1. Install the AWS command line interface using [the provided executable](https://aws.amazon.com/cli/) or `uv tool install awscli`, which allows users to store credentials, query Athena, move S3 objects, etc. The CLI on Windows can be accessed via PowerShell. On Linux or macOS it can be accessed via a standard terminal. If your intention is to connect to AWS via the Data team server, ensure that you are connected and logged in to the server first. 
 2. Log into the [AWS Console](https://ccao-data.signin.aws.amazon.com/console) and under your account select "My Security Credentials". Enable MFA, then create an access key. You'll need both the `Access Key ID`, the `Secret Access Key`, and the name of the `Assigned MFA Device`. Do not include `(Virtual)` when copying the name of the MFA device.
 3. In the command line run:
    - `aws configure` and enter your `Access Key ID`, `Secret Access Key`, region (`us-east-1`), and `json` for output.
-   - `pip install aws-mfa`
+   - `uv tool install aws-mfa`
 4. Open your credentials file located at `~/.aws/credentials` on Linux or macOS, or at `C:\Users\$USERNAME\.aws\credentials` on Windows and rename `[default]` to `[default-long-term]`.
 5. Underneath `aws_secret_access_key` type `aws_mfa_device = $MFA_DEVICE` where `$MFA_DEVICE` is the previously copied `Assigned MFA Device` from the AWS Console. Save the file.
 6. In the command line, run `aws-mfa` and enter the current MFA token provided by your `Assigned MFA Device`.


### PR DESCRIPTION
I noticed while [investigating first-party AWS CLI MFA](https://github.com/orgs/ccao-data/projects/22/views/9?pane=issue&itemId=154498748) that our AWS CLI docs are out of date, and they recommend commands that won't work for installing the AWS CLI or `aws-mfa`. This PR fixes that error by tweaking the docs to specify the correct install commands using uv.