### PR TITLE
Update annual chore issue template to document Tableau year filters

### DIFF
--- a/.github/ISSUE_TEMPLATE/annual-chores.md
+++ b/.github/ISSUE_TEMPLATE/annual-chores.md
@@ -46,3 +46,5 @@ These chores must be completed once a year following the iasWorld rollover:
       - Click **OK** twice to save the update to the action and close the
         Properties dialog
       - Test the change by right-clicking the task and selecting **Run**
+- [ ] Update Tableau dashboards that filter for the current assessment year
+    - [ ] Town Close QC Reports


### PR DESCRIPTION
We realized today that we will need to manually update the town close QC workbooks in Tableau each year to bump the assessment year filter. This PR documents that chore in our `annual-chores.md` issue template.