### PR TITLE
Document Node installation in dev env setup instructions

### DIFF
--- a/Handbook/Local-Dev-Environment-Setup.md
+++ b/Handbook/Local-Dev-Environment-Setup.md
@@ -203,6 +203,27 @@ uv tool install aws-mfa
 uv tool install pre-commit
 ```
 
+- Install [Node](https://nodejs.org/en/download) using
+  [nvm](https://github.com/nvm-sh/nvm):
+
+```bash
+# Download and install nvm
+curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.6/install.sh | bash
+
+# nvm will initialize on shell startup, but force it to initialize now so that
+# we don't have to open a new shell
+\. "$HOME/.nvm/nvm.sh"
+
+# Download and install Node
+nvm install 24
+
+# Verify Node version (should print "v24.19.0")
+node -v
+
+# Verify npm version (should print "11.17.0")
+npm -v
+```
+
 ### Mandatory R configurations
 
 The following configs will help you work with our R projects.


### PR DESCRIPTION
This PR adds a section to the local dev env docs we added in #71 to document installing [Node](https://nodejs.org) with [nvm](https://github.com/nvm-sh/nvm). This is important because we have added [`markdownlint-cli`](https://github.com/igorshubovych/markdownlint-cli) to our pre-commit toolchain starting in https://github.com/ccao-data/public/pull/49, and `markdownlint-cli` requires Node.

Closes #80.